### PR TITLE
Remove null terminator from strings

### DIFF
--- a/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
+++ b/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
@@ -47,7 +47,7 @@ namespace Eryph.ConfigModel.Converters
 
         protected static string GetStringProperty(IDictionary<string, object> dictionary, params string[] propertyNames)
         {
-            return GetValueCaseInvariant(dictionary, propertyNames)?.ToString();
+            return GetValueCaseInvariant(dictionary, propertyNames)?.ToString().TrimEnd(char.MinValue);
         }
 
         protected static int GetIntProperty(IDictionary<string, object> dictionary, params string[] propertyNames)

--- a/test/Eryph.ConfigModel.Machine.Tests/ConverterTestBase.cs
+++ b/test/Eryph.ConfigModel.Machine.Tests/ConverterTestBase.cs
@@ -47,5 +47,6 @@ public class ConverterTestBase
         config.Provisioning.Config[0].FileName.Should().Be("filename");
         config.Provisioning.Config[0].Sensitive.Should().Be(true);
         config.Provisioning.Config[0].Content.Should().Contain("- name: Admin");
+        config.Provisioning.Config[0].Content.Should().NotEndWith("\0");
     }
 }


### PR DESCRIPTION
Remove null terminators from strings. This may happen in yaml content with multiline strings and will cause cloud-init config to fail.