### PR TITLE
added fodder gene configuration yaml

### DIFF
--- a/src/Eryph.ConfigModel.Catlets.Yaml/Yaml/FodderGeneConfigYamlSerializer.cs
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/Yaml/FodderGeneConfigYamlSerializer.cs
@@ -30,6 +30,6 @@ public static class FodderGeneConfigYamlSerializer
                 .Build();
 
         var dictionary = _deSerializer.Deserialize<Dictionary<object, object>>(yaml);
-        return FodderConfigDictionaryConverter.Convert(dictionary, true);
+        return FodderGeneConfigDictionaryConverter.Convert(dictionary, true);
     }
 }

--- a/src/Eryph.ConfigModel.Catlets.Yaml/Yaml/FodderGeneConfigYamlSerializer.cs
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/Yaml/FodderGeneConfigYamlSerializer.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Eryph.ConfigModel.FodderGenes;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Eryph.ConfigModel.Yaml;
+
+public static class FodderGeneConfigYamlSerializer
+{
+    private static ISerializer? _serializer;
+    private static IDeserializer? _deSerializer;
+
+    public static string Serialize(FodderGeneConfig config)
+    {
+        if (_serializer == null)
+        {
+            _serializer = new SerializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+                .Build();
+        }
+
+        return _serializer.Serialize(config);
+    }
+
+    public static FodderGeneConfig Deserialize(string yaml)
+    {
+        if (_deSerializer == null)
+            _deSerializer = new DeserializerBuilder()
+                .Build();
+
+        var dictionary = _deSerializer.Deserialize<Dictionary<object, object>>(yaml);
+        return FodderConfigDictionaryConverter.Convert(dictionary, true);
+    }
+}

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfig.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 namespace Eryph.ConfigModel.Catlets
 {
     [PublicAPI]
-    public class CatletConfig: ICloneable
+    public class CatletConfig: ICloneable, IHasFodderConfig
     {
         public string? Version { get; set; }
         public string? Project { get; set; }

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfigDictionaryConverter.cs
@@ -28,8 +28,8 @@ namespace Eryph.ConfigModel.Catlets
                 new CatletNetworkConfigConverter(),
                 new CatletNetworkConfigConverter.List(),
                 new CatletSubnetConfigConverter(),
-                new CloudInitConfigConverter(),
-                new CloudInitConfigConverter.List(),
+                new FodderConfigConverter<CatletConfig>(),
+                new FodderConfigConverter<CatletConfig>.List(),
                 looseMode
                     ? new LooseCatletCapabilitiesConfigConverter()
                     : new StrictCatletCapabilityConfigConverter(),

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CatletConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CatletConfigConverter.cs
@@ -34,7 +34,5 @@ namespace Eryph.ConfigModel.Catlets.Converters
             return context.Target;
         }
 
-
-
     }
 }

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CatletConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CatletConfigConverter.cs
@@ -14,6 +14,7 @@ namespace Eryph.ConfigModel.Catlets.Converters
             // target should be initialized
             context.Target = new CatletConfig
             {
+                Version = GetStringProperty(dictionary, nameof(CatletConfig.Version)),
                 Name = GetStringProperty(dictionary, nameof(CatletConfig.Name)),
                 Environment = GetStringProperty(dictionary, nameof(CatletConfig.Environment)),
                 Project = GetStringProperty(dictionary, nameof(CatletConfig.Project)),

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CloudInitConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/CloudInitConfigConverter.cs
@@ -5,27 +5,36 @@ using Eryph.ConfigModel.Converters;
 
 namespace Eryph.ConfigModel.Catlets.Converters
 {
-    public class CloudInitConfigConverter : DictionaryConverterBase<FodderConfig, CatletConfig>
+    public class FodderConfigConverter<TConfig> : DictionaryConverterBase<FodderConfig, TConfig>
+       where TConfig : IHasFodderConfig
     {
-        public class List : DictionaryToListConverter<FodderConfig[], CatletConfig>
+        public class List : DictionaryToListConverter<FodderConfig[], TConfig>
         {
             public List() : base(nameof(CatletConfig.Fodder))
             {
             }
         }
 
-        public override FodderConfig ConvertFromDictionary(IConverterContext<CatletConfig> context, 
+        public override FodderConfig ConvertFromDictionary(IConverterContext<TConfig> context, 
             IDictionary<object, object> dictionary, object? data = null)
         {
-            return new FodderConfig
+            var res = new FodderConfig
             {
                 Name = GetStringProperty(dictionary, nameof(FodderConfig.Name)),
+                Source = GetStringProperty(dictionary, nameof(FodderConfig.Source)),
                 Type = GetStringProperty(dictionary, nameof(FodderConfig.Type)),
                 Content = GetStringProperty(dictionary, nameof(FodderConfig.Content)),
-                FileName = GetStringProperty(dictionary, nameof(FodderConfig.FileName)),
-                Secret = Convert.ToBoolean(GetStringProperty(dictionary, nameof(FodderConfig.Secret)), CultureInfo.InvariantCulture)
+                FileName = GetStringProperty(dictionary, nameof(FodderConfig.FileName))
             };
+
+            var secretString = GetStringProperty(dictionary, nameof(FodderConfig.Secret));
+            if(!string.IsNullOrEmpty(secretString))
+                res.Secret = bool.Parse(secretString);
+
+            return res;
         }
+
+
 
     }
 }

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
@@ -10,7 +10,7 @@ namespace Eryph.ConfigModel.Catlets.Converters
     {
         public class List : DictionaryToListConverter<FodderConfig[], TConfig>
         {
-            public List() : base(nameof(CatletConfig.Fodder))
+            public List() : base(nameof(IHasFodderConfig.Fodder))
             {
             }
         }

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
@@ -31,6 +31,11 @@ namespace Eryph.ConfigModel.Catlets.Converters
             if(!string.IsNullOrEmpty(secretString))
                 res.Secret = bool.Parse(secretString);
 
+            var removeString = GetStringProperty(dictionary, nameof(FodderConfig.Remove));
+            if (!string.IsNullOrEmpty(removeString))
+                res.Remove = bool.Parse(removeString);
+
+
             return res;
         }
 

--- a/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
@@ -58,14 +58,14 @@ namespace Eryph.ConfigModel.Catlets
                 
                 foreach (var fodder in newConfigs)
                 {
-                    if(string.IsNullOrWhiteSpace(fodder.Source))
+                    if (fodder.Remove.GetValueOrDefault() && !string.IsNullOrWhiteSpace(fodder.Name))
+                        mergedConfig.Remove(fodder);
+
+                    if (string.IsNullOrWhiteSpace(fodder.Source))
                     {
                         fodder.Source = $"gene:{parentReference}:{fodder.Name}";
                     }
                     
-                    if (fodder.Remove.GetValueOrDefault())
-                        mergedConfig.Remove(fodder);
-
                     var childFodder = childConfig.Fodder?
                         .FirstOrDefault(x => x.Name == fodder.Name);
 

--- a/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
@@ -58,8 +58,6 @@ namespace Eryph.ConfigModel.Catlets
                 
                 foreach (var fodder in newConfigs)
                 {
-                    if (fodder.Remove.GetValueOrDefault() && !string.IsNullOrWhiteSpace(fodder.Name))
-                        mergedConfig.Remove(fodder);
 
                     if (string.IsNullOrWhiteSpace(fodder.Source))
                     {
@@ -72,7 +70,9 @@ namespace Eryph.ConfigModel.Catlets
                     if (childFodder == null)
                         continue;
 
-                    if (childFodder.Remove.GetValueOrDefault())
+                    if (childFodder.Remove.GetValueOrDefault() 
+                        && !string.IsNullOrWhiteSpace(fodder.Name) && 
+                        childFodder.Name == fodder.Name)
                     {
                         mergedConfig.Remove(fodder);
                         continue;
@@ -85,13 +85,13 @@ namespace Eryph.ConfigModel.Catlets
                     fodder.Content = childFodder.Content ?? fodder.Content;
                     fodder.Type = childFodder.Type ?? fodder.Type;
                     fodder.FileName = childFodder.FileName ?? fodder.FileName;
+                    fodder.Remove = childFodder.Remove ?? fodder.Remove;
                 }
             }
 
             var parentNames = parentConfig.Fodder
                 ?.Select(x => x.Name) ?? Array.Empty<string>();
             mergedConfig.AddRange(childConfig.Fodder?.Where(cfg =>
-                                      !cfg.Remove.GetValueOrDefault() &&                      
                                       !parentNames.Any(x =>
                                           string.Equals(x, cfg.Name, StringComparison.InvariantCultureIgnoreCase))) 
                                   ?? Array.Empty<FodderConfig>());

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Eryph.ConfigModel.Catlets.Converters;
+using Eryph.ConfigModel.Converters;
+
+namespace Eryph.ConfigModel.FodderGenes;
+
+public static class FodderConfigDictionaryConverter
+{
+
+    public static FodderGeneConfig Convert(IDictionary<object, object>? dictionary, bool looseMode = false)
+    {
+        if (dictionary == null)
+            return new FodderGeneConfig();
+
+        var converters = new IDictionaryConverter<FodderGeneConfig>[]
+        {
+            new FodderGeneConfigConverter(),
+            new FodderConfigConverter<FodderGeneConfig>(),
+            new FodderConfigConverter<FodderGeneConfig>.List(),
+        };
+
+        var context = new ConverterContext<FodderGeneConfig>(dictionary,
+            new DictionaryConverterProvider<FodderGeneConfig>(converters));
+
+        return context.Convert<FodderGeneConfig>(dictionary) ?? new FodderGeneConfig();
+    }
+
+
+}

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
@@ -4,7 +4,7 @@ using Eryph.ConfigModel.Converters;
 
 namespace Eryph.ConfigModel.FodderGenes;
 
-public static class FodderConfigDictionaryConverter
+public static class FodderGeneConfigDictionaryConverter
 {
 
     public static FodderGeneConfig Convert(IDictionary<object, object>? dictionary, bool looseMode = false)

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfig.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using Eryph.ConfigModel.Catlets;
+using JetBrains.Annotations;
+
+namespace Eryph.ConfigModel.FodderGenes;
+
+[PublicAPI]
+public class FodderGeneConfig : ICloneable, IHasFodderConfig
+{
+    public string? Version { get; set; }
+    public string? Name { get; set; }
+
+    public FodderConfig[]? Fodder { get; set; }
+
+    public FodderGeneConfig Clone()
+    {
+        return new FodderGeneConfig()
+        {
+            Version = Version,
+            Name = Name,
+            Fodder = Fodder?.Select(x => x.Clone()).ToArray(),
+        };
+    }
+
+    object ICloneable.Clone()
+    {
+        return Clone();
+    }
+}

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfigConverter.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Converters;
+
+namespace Eryph.ConfigModel.FodderGenes;
+
+public class FodderGeneConfigConverter : DictionaryConverterBase<FodderGeneConfig, FodderGeneConfig>
+{
+
+    public override FodderGeneConfig ConvertFromDictionary(
+        IConverterContext<FodderGeneConfig> context, IDictionary<object, object> dictionary, object? data = null)
+    {
+
+        // ReSharper disable once UseObjectOrCollectionInitializer
+        // target should be initialized
+        context.Target = new FodderGeneConfig
+        {
+            Name = GetStringProperty(dictionary, nameof(CatletConfig.Name)),
+        };
+
+        context.Target.Fodder = context.ConvertList<FodderConfig>(dictionary);
+
+        return context.Target;
+    }
+
+}

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderGeneConfigConverter.cs
@@ -15,7 +15,8 @@ public class FodderGeneConfigConverter : DictionaryConverterBase<FodderGeneConfi
         // target should be initialized
         context.Target = new FodderGeneConfig
         {
-            Name = GetStringProperty(dictionary, nameof(CatletConfig.Name)),
+            Version = GetStringProperty(dictionary, nameof(FodderGeneConfig.Version)),
+            Name = GetStringProperty(dictionary, nameof(FodderGeneConfig.Name)),
         };
 
         context.Target.Fodder = context.ConvertList<FodderConfig>(dictionary);

--- a/src/Eryph.ConfigModel.Catlets/IHasFodderConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/IHasFodderConfig.cs
@@ -1,0 +1,9 @@
+﻿using Eryph.ConfigModel.Catlets;
+
+namespace Eryph.ConfigModel;
+
+public interface IHasFodderConfig
+{
+    public FodderConfig[]? Fodder { get; set; }
+
+}

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
@@ -371,6 +371,80 @@ public class BreedingTests
 
     }
 
+    [Fact]
+    public void Fodder_is_removed()
+    {
+        var parent = new CatletConfig
+        {
+            Name = "Parent",
+            Fodder = new[]
+            {
+                new FodderConfig()
+                {
+                    Name = "cfg",
+                    Type = "type1",
+                    Content = "contenta",
+                    FileName = "filenamea"
+                }
+            }
+        };
+
+        var child = new CatletConfig
+        {
+            Name = "child",
+            Fodder = new[]
+            {
+                new FodderConfig()
+                {
+                    Name = "cfg",
+                    Remove = true
+                }
+            }
+        };
+
+        var breedChild = parent.Breed(child);
+
+        breedChild.Fodder.Should().NotBeNull();
+        breedChild.Fodder.Should().HaveCount(0);
+
+    }
+
+    [Fact]
+    public void Fodder_from_source_is_not_removed()
+    {
+        var parent = new CatletConfig
+        {
+            Name = "Parent",
+            Fodder = new[]
+            {
+                new FodderConfig()
+                {
+                    Source = "gene:somegene/utt/123:gene1"
+                }
+            }
+        };
+
+        var child = new CatletConfig
+        {
+            Name = "child",
+            Fodder = new[]
+            {
+                new FodderConfig()
+                {
+                    Source = "gene:somegene/utt/123:gene1",
+                    Remove = true
+                }
+            }
+        };
+
+        var breedChild = parent.Breed(child);
+
+        breedChild.Fodder.Should().NotBeNull();
+        breedChild.Fodder.Should().HaveCount(1);
+        breedChild.Fodder?[0].Source.Should().Be("gene:somegene/utt/123:gene1");
+        breedChild.Fodder?[0].Remove.Should().BeTrue();
+    }
+
     [Theory]
     [InlineData(MutationType.Merge, 2)]
     [InlineData(MutationType.Remove, 1)]

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
@@ -3,7 +3,7 @@ using Eryph.ConfigModel.Catlets;
 using FluentAssertions;
 using Xunit;
 
-namespace Eryph.ConfigModel.Catlet.Tests;
+namespace Eryph.ConfigModel.Catlet.Tests.Catlets;
 
 public class BreedingTests
 {
@@ -25,7 +25,7 @@ public class BreedingTests
             {
                 new CatletDriveConfig
                 {
-                    Name = "sda", 
+                    Name = "sda",
                     Type = CatletDriveType.VHD,
                     Store = "lair",
                     Size = 100
@@ -54,16 +54,18 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             Project = "social",
             Environment = "env1",
             Drives = Array.Empty<CatletDriveConfig>(),
-            Networks = new []{new CatletNetworkConfig
+            Networks = new[]{new CatletNetworkConfig
             {
                 Name = "default",
                 AdapterName = "eth0"
             }},
-            Fodder = new []{new FodderConfig
+            Fodder = new[]{new FodderConfig
             {
                 Name = "food"
             }}
@@ -73,22 +75,22 @@ public class BreedingTests
         breedChild.Parent.Should().Be("reference");
         breedChild.Project.Should().Be("social");
         breedChild.Environment.Should().Be("env1");
-        
+
         breedChild.Capabilities.Should().NotBeNull();
         breedChild.Capabilities.Should().BeEquivalentTo(parent.Capabilities);
         breedChild.Capabilities.Should().NotBeSameAs(parent.Capabilities);
-        
+
         breedChild.Drives.Should().NotBeNull();
         breedChild.Drives.Should().HaveCount(1);
         breedChild.Drives.Should().NotBeEquivalentTo(parent.Drives);
         breedChild.Drives?[0].Source.Should().Be("gene:reference:sda");
         breedChild.Drives.Should().NotBeSameAs(parent.Drives);
-        
+
         breedChild.NetworkAdapters.Should().NotBeNull();
         breedChild.NetworkAdapters.Should().HaveCount(1);
         breedChild.NetworkAdapters.Should().BeEquivalentTo(parent.NetworkAdapters);
         breedChild.NetworkAdapters.Should().NotBeSameAs(parent.NetworkAdapters);
-        
+
         breedChild.Networks.Should().NotBeNull();
         breedChild.Networks.Should().HaveCount(1);
         breedChild.Networks.Should().BeEquivalentTo(parent.Networks);
@@ -114,15 +116,18 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
-            Capabilities = new [] { new CatletCapabilityConfig
+        var child = new CatletConfig
+        {
+            Name = "child",
+            Capabilities = new[] { new CatletCapabilityConfig
             {
                 Name = "Cap1",
                 Details = new []{"detail2"}
-            }}};
-        
+            }}
+        };
+
         var breedChild = parent.Breed(child);
-        
+
         breedChild.Capabilities.Should().NotBeNull();
         breedChild.Capabilities.Should().NotBeEquivalentTo(parent.Capabilities);
         breedChild.Capabilities.Should().HaveCount(1);
@@ -130,7 +135,7 @@ public class BreedingTests
 
 
     }
-    
+
     [Fact]
     public void Drives_are_merged()
     {
@@ -152,7 +157,9 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             Drives = new[]
             {
                 new CatletDriveConfig
@@ -167,10 +174,11 @@ public class BreedingTests
                     Store = "none",
                     Location = "peng"
                 }
-            }};
-        
+            }
+        };
+
         var breedChild = parent.Breed(child, "reference");
-        
+
         breedChild.Drives.Should().NotBeNull();
         breedChild.Drives.Should().NotBeEquivalentTo(parent.Drives);
         breedChild.Drives.Should().HaveCount(2);
@@ -182,7 +190,7 @@ public class BreedingTests
         breedChild.Drives?[1].Source.Should().BeNull();
         breedChild.Drives?[1].Location.Should().Be("peng");
     }
-    
+
     [Fact]
     public void NetworkAdapters_are_merged()
     {
@@ -199,7 +207,9 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             NetworkAdapters = new[]
             {
                 new CatletNetworkAdapterConfig()
@@ -207,17 +217,18 @@ public class BreedingTests
                     Name = "sda",
                     MacAddress = "addr2"
                 }
-            }};
-        
+            }
+        };
+
         var breedChild = parent.Breed(child);
-        
+
         breedChild.NetworkAdapters.Should().NotBeNull();
         breedChild.NetworkAdapters.Should().NotBeEquivalentTo(parent.NetworkAdapters);
         breedChild.NetworkAdapters.Should().HaveCount(1);
         breedChild.NetworkAdapters?[0].MacAddress.Should().Be("addr2");
 
     }
-    
+
     [Fact]
     public void Networks_are_merged()
     {
@@ -244,7 +255,9 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             Networks = new[]
             {
                 new CatletNetworkConfig()
@@ -256,10 +269,11 @@ public class BreedingTests
                         Name = "none-default"
                     }
                 }
-            }};
-        
+            }
+        };
+
         var breedChild = parent.Breed(child);
-        
+
         breedChild.Networks.Should().NotBeNull();
         breedChild.Networks.Should().NotBeEquivalentTo(parent.Networks);
         breedChild.Networks.Should().HaveCount(1);
@@ -272,7 +286,7 @@ public class BreedingTests
         breedChild.Networks?[0].SubnetV6?.IpPool.Should().Be("default");
 
     }
-    
+
     [Fact]
     public void Memory_is_merged()
     {
@@ -287,22 +301,25 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             Memory = new CatletMemoryConfig
             {
                 Startup = 2049,
                 Minimum = 1025,
                 Maximum = 9097
-            }};
-        
+            }
+        };
+
         var breedChild = parent.Breed(child);
-        
+
         breedChild.Memory.Should().NotBeNull();
         breedChild.Memory?.Startup.Should().Be(2049);
         breedChild.Memory?.Minimum.Should().Be(1025);
         breedChild.Memory?.Maximum.Should().Be(9097);
     }
-    
+
     [Fact]
     public void Fodder_is_mixed()
     {
@@ -321,7 +338,9 @@ public class BreedingTests
             }
         };
 
-        var child = new CatletConfig { Name = "child", 
+        var child = new CatletConfig
+        {
+            Name = "child",
             Fodder = new[]
             {
                 new FodderConfig()
@@ -331,17 +350,18 @@ public class BreedingTests
                     Content = "contentb",
                     FileName = "filenameb"
                 }
-            }};
-        
+            }
+        };
+
         var breedChild = parent.Breed(child);
-        
+
         breedChild.Fodder.Should().NotBeNull();
         breedChild.Fodder.Should().NotBeEquivalentTo(parent.Fodder);
         breedChild.Fodder.Should().HaveCount(1);
         breedChild.Fodder?[0].Type.Should().Be("type2");
         breedChild.Fodder?[0].Content.Should().Be("contentb");
         breedChild.Fodder?[0].FileName.Should().Be("filenameb");
-        
+
     }
 
     [Theory]
@@ -370,7 +390,7 @@ public class BreedingTests
                 },
             }
         };
-        
+
         var child = new CatletConfig
         {
             Capabilities = new[]
@@ -398,5 +418,5 @@ public class BreedingTests
             breedChild.Capabilities?[0].Details.Should().BeEquivalentTo(new[] { "none" });
         }
     }
-    
+
 }

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
@@ -51,6 +51,11 @@ public class BreedingTests
                         IpPool = "pool1"
                     }
                 }
+            },
+            Fodder = new []{new FodderConfig
+                {
+                    Source = "food_from_somewhere_else"
+                }
             }
         };
 
@@ -68,7 +73,8 @@ public class BreedingTests
             Fodder = new[]{new FodderConfig
             {
                 Name = "food"
-            }}
+            }
+            }
         };
         var breedChild = parent.Breed(child, "reference");
 
@@ -97,7 +103,8 @@ public class BreedingTests
         breedChild.Networks.Should().NotBeSameAs(parent.Networks);
 
         breedChild.Fodder.Should().NotBeNull();
-        breedChild.Fodder.Should().HaveCount(1);
+        breedChild.Fodder.Should().HaveCount(2);
+        breedChild.Fodder?[0].Source.Should().Be("food_from_somewhere_else");
     }
 
     [Fact]

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/CloneableTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/CloneableTests.cs
@@ -4,25 +4,25 @@ using Eryph.ConfigModel.Catlets;
 using FluentAssertions;
 using Xunit;
 
-namespace Eryph.ConfigModel.Catlet.Tests;
+namespace Eryph.ConfigModel.Catlet.Tests.Catlets;
 
 public class CloneableTests
 {
     private static readonly CatletConfig TestData = new CatletConfig
     {
-        Capabilities = new[] { new CatletCapabilityConfig{Name = "one"}},
-        Cpu = new CatletCpuConfig{Count = 2},
-        Memory = new CatletMemoryConfig{Startup = 1},
-        NetworkAdapters = new[] { new CatletNetworkAdapterConfig{Name = "eth0"} },
-        Drives = new[] { new CatletDriveConfig{Name = "sda"} },
-        Fodder = new[] { new FodderConfig{Name = "food"} },
+        Capabilities = new[] { new CatletCapabilityConfig { Name = "one" } },
+        Cpu = new CatletCpuConfig { Count = 2 },
+        Memory = new CatletMemoryConfig { Startup = 1 },
+        NetworkAdapters = new[] { new CatletNetworkAdapterConfig { Name = "eth0" } },
+        Drives = new[] { new CatletDriveConfig { Name = "sda" } },
+        Fodder = new[] { new FodderConfig { Name = "food" } },
         Networks = new[] { new CatletNetworkConfig
         {
             Name = "nw",
             SubnetV4 = new CatletSubnetConfig{Name = "name"}
         } },
     };
-    
+
     [Fact]
     public void CatletConfig_is_cloned()
     {
@@ -32,19 +32,19 @@ public class CloneableTests
 
         clonedConfig.Cpu.Should().NotBeNull();
         clonedConfig.Cpu.Should().NotBeSameAs(TestData.Cpu);
-        
+
         clonedConfig.Memory.Should().NotBeNull();
         clonedConfig.Memory.Should().NotBeSameAs(TestData.Memory);
-        
+
         clonedConfig.NetworkAdapters.Should().NotBeNull();
         clonedConfig.NetworkAdapters.Should().NotBeSameAs(TestData.NetworkAdapters);
-        
+
         clonedConfig.Drives.Should().NotBeNull();
         clonedConfig.Drives.Should().NotBeSameAs(TestData.Drives);
-        
+
         clonedConfig.Fodder.Should().NotBeNull();
         clonedConfig.Fodder.Should().NotBeSameAs(TestData.Fodder);
-        
+
         clonedConfig.Fodder.Should().NotBeNull();
         clonedConfig.Fodder.Should().NotBeSameAs(TestData.Fodder);
     }
@@ -60,7 +60,7 @@ public class CloneableTests
         clonedConfig.Should().NotBeSameAs(TestData.Cpu);
         clonedConfig.Should().BeEquivalentTo(TestData.Cpu);
     }
-    
+
     [Fact]
     public void MemoryConfig_is_cloned()
     {
@@ -72,7 +72,7 @@ public class CloneableTests
         clonedConfig.Should().NotBeSameAs(TestData.Memory);
         clonedConfig.Should().BeEquivalentTo(TestData.Memory);
     }
-    
+
     [Fact]
     public void SubnetConfig_is_cloned()
     {
@@ -84,7 +84,7 @@ public class CloneableTests
         clonedConfig.Should().NotBeSameAs(TestData.Networks?[0].SubnetV4);
         clonedConfig.Should().BeEquivalentTo(TestData.Networks?[0].SubnetV4);
     }
-    
+
     [Fact]
     public void Capabilities_are_cloned()
     {
@@ -108,36 +108,36 @@ public class CloneableTests
         cloned.Should().NotBeNull();
         cloned.Should().HaveCount(1);
     }
-    
+
     [Fact]
     public void Drives_are_cloned()
     {
         var cloned = TestData.Drives?
             .Select(a => (a as ICloneable).Clone())
             .Cast<CatletDriveConfig>().ToArray();
-        
+
         cloned.Should().NotBeNull();
         cloned.Should().HaveCount(1);
     }
-    
+
     [Fact]
     public void Networks_are_cloned()
     {
         var cloned = TestData.Networks?
             .Select(a => (a as ICloneable).Clone())
             .Cast<CatletNetworkConfig>().ToArray();
-        
+
         cloned.Should().NotBeNull();
         cloned.Should().HaveCount(1);
     }
-    
+
     [Fact]
     public void Fodder_is_cloned()
     {
         var cloned = TestData.Fodder?
             .Select(a => (a as ICloneable).Clone())
             .Cast<FodderConfig>().ToArray();
-        
+
         cloned.Should().NotBeNull();
         cloned.Should().HaveCount(1);
     }

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/ConverterTestBase.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/ConverterTestBase.cs
@@ -1,7 +1,7 @@
 using Eryph.ConfigModel.Catlets;
 using FluentAssertions;
 
-namespace Eryph.ConfigModel.Catlet.Tests;
+namespace Eryph.ConfigModel.Catlet.Tests.Catlets;
 
 public class ConverterTestBase
 {
@@ -26,7 +26,7 @@ public class ConverterTestBase
         config.Drives?[0].Source.Should().Be("some_template");
         config.Drives?[0].Type.Should().Be(CatletDriveType.SharedVHD);
         config.Drives?[0].Mutation.Should().Be(MutationType.Overwrite);
-        
+
         config.NetworkAdapters.Should().HaveCount(2);
         config.NetworkAdapters?[0].Name.Should().Be("eth0");
         config.NetworkAdapters?[0].MacAddress.Should().Be("4711");

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/JsonConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/JsonConverterTests.cs
@@ -4,11 +4,11 @@ using Eryph.ConfigModel.Json;
 using FluentAssertions;
 using Xunit;
 
-namespace Eryph.ConfigModel.Catlet.Tests;
+namespace Eryph.ConfigModel.Catlet.Tests.Catlets;
 
-public class JsonConverterTests: ConverterTestBase
+public class JsonConverterTests : ConverterTestBase
 {
-    
+
     private const string SampleJson1 = $@"{{
   ""project"": ""homeland"",
   ""name"": ""cinc-windows"",
@@ -106,7 +106,7 @@ public class JsonConverterTests: ConverterTestBase
         {
             WriteIndented = true
         };
-        var act = ConfigModelJsonSerializer.Serialize(config,copyOptions );
+        var act = ConfigModelJsonSerializer.Serialize(config, copyOptions);
         act.Should().Be(expected);
 
     }

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/YamlConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/YamlConverterTests.cs
@@ -5,12 +5,12 @@ using FluentAssertions;
 using Xunit;
 using YamlDotNet.Serialization;
 
-namespace Eryph.ConfigModel.Catlet.Tests
+namespace Eryph.ConfigModel.Catlet.Tests.Catlets
 {
     public class YamlConverterTests : ConverterTestBase
     {
 
-      private const string SampleYaml1 = @"project: homeland
+        private const string SampleYaml1 = @"project: homeland
 name: cinc-windows
 location: cinc
 hostname: cinc-host
@@ -65,37 +65,37 @@ fodder:
   file_name: filename
   secret: true
 ";
-      
-      private const string SampleYaml2 = @"parent: dbosoft/winsrv2019-standard/20220324";
 
-      private const string SampleYaml3 = @"
+        private const string SampleYaml2 = @"parent: dbosoft/winsrv2019-standard/20220324";
+
+        private const string SampleYaml3 = @"
 parent: dbosoft/winsrv2019-standard/20220324  
 cpu: 4
-";      
-      
-      private const string SampleYaml4 = @"
+";
+
+        private const string SampleYaml4 = @"
 capabilities:
   - nested_virtualization
-";           
-      
+";
+
         [Fact]
         public void Converts_from_yaml()
         {
-          var serializer = new DeserializerBuilder()
-            .Build();
-          
+            var serializer = new DeserializerBuilder()
+              .Build();
+
             var dictionary = serializer.Deserialize<Dictionary<object, object>>(SampleYaml1);
             var config = CatletConfigDictionaryConverter.Convert(dictionary, true);
             AssertSample1(config);
         }
-        
+
         [Theory()]
         [InlineData(SampleYaml1, SampleYaml1)]
         public void Converts_To_yaml(string input, string expected)
         {
-          var config = CatletConfigYamlSerializer.Deserialize(input);
-          var act = CatletConfigYamlSerializer.Serialize(config);
-          act.Should().Be(expected);
+            var config = CatletConfigYamlSerializer.Deserialize(input);
+            var act = CatletConfigYamlSerializer.Serialize(config);
+            act.Should().Be(expected);
 
         }
 
@@ -119,16 +119,16 @@ capabilities:
             config.Cpu?.Count.Should().Be(4);
 
         }
-        
+
         [Fact]
         public void Convert_from_short_features_yaml()
         {
-          var config = CatletConfigYamlSerializer.Deserialize(SampleYaml4);
+            var config = CatletConfigYamlSerializer.Deserialize(SampleYaml4);
 
-          config.Should().NotBeNull();
-          config.Capabilities.Should().NotBeNull();
-          config.Capabilities.Should().HaveCount(1);
-          config.Capabilities?[0].Name.Should().Be("nested_virtualization");
+            config.Should().NotBeNull();
+            config.Capabilities.Should().NotBeNull();
+            config.Capabilities.Should().HaveCount(1);
+            config.Capabilities?[0].Name.Should().Be("nested_virtualization");
 
         }
     }

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/ConverterTestBase.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/ConverterTestBase.cs
@@ -1,0 +1,24 @@
+using Eryph.ConfigModel.FodderGenes;
+using FluentAssertions;
+
+namespace Eryph.ConfigModel.Catlet.Tests.FodderGenes;
+
+public class ConverterTestBase
+{
+    protected static void AssertSample1(FodderGeneConfig config)
+    {
+        config.Should().NotBeNull();
+        config.Name.Should().Be("fodder1");
+        config.Fodder.Should().NotBeNull();
+        config.Fodder.Should().HaveCount(2);
+        config.Fodder?[0].Name.Should().Be("admin-windows");
+        config.Fodder?[0].Type.Should().Be("cloud-config");
+        config.Fodder?[0].FileName.Should().Be("filename");
+        config.Fodder?[0].Secret.Should().Be(true);
+        config.Fodder?[0].Content.Should().Contain("- name: Admin");
+        config.Fodder?[0].Content.Should().NotEndWith("\0");
+
+        config.Fodder?[1].Name.Should().Be("super-dupa");
+        config.Fodder?[1].Type.Should().Be("cloud-config");
+    }
+}

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/JsonConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/JsonConverterTests.cs
@@ -32,7 +32,7 @@ public class JsonConverterTests : ConverterTestBase
     public void Converts_from_json()
     {
         var dictionary = ConfigModelJsonSerializer.DeserializeToDictionary(SampleJson1);
-        var config = FodderConfigDictionaryConverter.Convert(dictionary);
+        var config = FodderGeneConfigDictionaryConverter.Convert(dictionary);
         AssertSample1(config);
     }
 
@@ -41,7 +41,7 @@ public class JsonConverterTests : ConverterTestBase
     public void Converts_to_json(string input, string expected)
     {
         var dictionary = ConfigModelJsonSerializer.DeserializeToDictionary(input);
-        var config = FodderConfigDictionaryConverter.Convert(dictionary, false);
+        var config = FodderGeneConfigDictionaryConverter.Convert(dictionary, false);
 
         var copyOptions = new JsonSerializerOptions(ConfigModelJsonSerializer.DefaultOptions)
         {

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/JsonConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/JsonConverterTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.FodderGenes;
+using Eryph.ConfigModel.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Eryph.ConfigModel.Catlet.Tests.FodderGenes;
+
+public class JsonConverterTests : ConverterTestBase
+{
+
+    private const string SampleJson1 = """
+                                       {
+                                         "name": "fodder1",
+                                         "fodder": [
+                                           {
+                                             "name": "admin-windows",
+                                             "type": "cloud-config",
+                                             "content": "users:\n  - name: Admin\ngroups: [ \u0022Administrators\u0022 ]\n  passwd: InitialPassw0rd",
+                                             "fileName": "filename",
+                                             "secret": true
+                                           },
+                                           {
+                                             "name": "super-dupa",
+                                             "type": "cloud-config"
+                                           }
+                                         ]
+                                       }
+                                       """;
+    [Fact]
+    public void Converts_from_json()
+    {
+        var dictionary = ConfigModelJsonSerializer.DeserializeToDictionary(SampleJson1);
+        var config = FodderConfigDictionaryConverter.Convert(dictionary);
+        AssertSample1(config);
+    }
+
+    [Theory]
+    [InlineData(SampleJson1, SampleJson1)]
+    public void Converts_to_json(string input, string expected)
+    {
+        var dictionary = ConfigModelJsonSerializer.DeserializeToDictionary(input);
+        var config = FodderConfigDictionaryConverter.Convert(dictionary, false);
+
+        var copyOptions = new JsonSerializerOptions(ConfigModelJsonSerializer.DefaultOptions)
+        {
+            WriteIndented = true
+        };
+        var act = ConfigModelJsonSerializer.Serialize(config, copyOptions);
+        act.Should().Be(expected);
+
+    }
+}

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/YamlConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/YamlConverterTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Eryph.ConfigModel.FodderGenes;
+using Eryph.ConfigModel.Yaml;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Serialization;
+
+namespace Eryph.ConfigModel.Catlet.Tests.FodderGenes
+{
+    public class YamlConverterTests : ConverterTestBase
+    {
+
+        private const string SampleYaml1 = @"name: fodder1
+fodder:
+- name: admin-windows
+  type: cloud-config
+  content: >-
+    users:
+      - name: Admin
+        groups: [ ""Administrators"" ]
+        passwd: InitialPassw0rd
+  file_name: filename
+  secret: true
+- name: super-dupa
+  type: cloud-config
+";
+
+
+        [Fact]
+        public void Converts_from_yaml()
+        {
+            var serializer = new DeserializerBuilder()
+              .Build();
+
+            var dictionary = serializer.Deserialize<Dictionary<object, object>>(SampleYaml1);
+            var config = FodderConfigDictionaryConverter.Convert(dictionary, true);
+            AssertSample1(config);
+        }
+
+        [Theory()]
+        [InlineData(SampleYaml1, SampleYaml1)]
+        public void Converts_To_yaml(string input, string expected)
+        {
+            var config = FodderGeneConfigYamlSerializer.Deserialize(input);
+            var act = FodderGeneConfigYamlSerializer.Serialize(config);
+            act.Should().Be(expected);
+
+        }
+
+    }
+}

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/YamlConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGenes/YamlConverterTests.cs
@@ -33,7 +33,7 @@ fodder:
               .Build();
 
             var dictionary = serializer.Deserialize<Dictionary<object, object>>(SampleYaml1);
-            var config = FodderConfigDictionaryConverter.Convert(dictionary, true);
+            var config = FodderGeneConfigDictionaryConverter.Convert(dictionary, true);
             AssertSample1(config);
         }
 


### PR DESCRIPTION
added feature to configure standalone fodder genes like this:

``` yaml
name: fodder1
fodder:
- name: admin-windows
  type: cloud-config
  content: >-
    users:
      - name: Admin
        groups: [ ""Administrators"" ]
        passwd: InitialPassw0rd
  file_name: filename
  secret: true
- name: super-dupa
  type: cloud-config
```

The breeding of catlets was also updated to handle "remove" flags for fodder better:

fodder could now be on its own gene, so it is possible to include it in 2 ways

all fodder from source
``` yaml

fodder: 
- source: gene:somegeneset:fodder-gene

```

or a single fodder
``` yaml
fodder: 
- source: gene:somegeneset:fodder-gene
  name: food
```

As source content is unknown during breeding we have to keep fooder that has a source set as be otherwise would not be able to remove it after resolving the fodder gene content. 
So breeding will now keep fodder that has to be removed when only source is specified and no name.
Removing such entries will have to be handled when building the resolved config. 

so now a child could either remove the entire fodder source:

``` yaml
fodder: 
- source: gene:somegeneset:fodder-gene
  remove: true
```

or a single food entry from the gene


``` yaml
fodder: 
- source: gene:somegeneset:fodder-gene
  name: food
  remove: true
```

