### PR TITLE
breeding: invalid source for drive generated

### DIFF
--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveConfig.cs
@@ -61,7 +61,8 @@ namespace Eryph.ConfigModel.Catlets
                 },
                 (drive) =>
                 {
-                    if(string.IsNullOrWhiteSpace(drive.Source))
+                    if(string.IsNullOrWhiteSpace(drive.Source) 
+                       && !string.IsNullOrWhiteSpace(parentReference))
                     {
                         drive.Source = $"gene:{parentReference}:{drive.Name}";
                     }


### PR DESCRIPTION
When parent reference is empty breeding generates invalid drive source like this: gene::driveName