### PR TITLE
Fix null value handling

### DIFF
--- a/ConfigModel.sln
+++ b/ConfigModel.sln
@@ -1,25 +1,27 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32106.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Catlets", "src\Eryph.ConfigModel.Catlets\Eryph.ConfigModel.Catlets.csproj", "{C71E688F-5BB5-4350-BD76-0CF0E2EC9473}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Catlets", "src\Eryph.ConfigModel.Catlets\Eryph.ConfigModel.Catlets.csproj", "{C71E688F-5BB5-4350-BD76-0CF0E2EC9473}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Catlets.Tests", "test\Eryph.ConfigModel.Catlets.Tests\Eryph.ConfigModel.Catlets.Tests.csproj", "{623F96D9-863D-4B21-9B88-9C76850B5996}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.System.Json", "src\Eryph.ConfigModel.System.Json\Eryph.ConfigModel.System.Json.csproj", "{36BEDF84-9E74-4A6A-A8B3-5D0FF7D2CCF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.System.Json", "src\Eryph.ConfigModel.System.Json\Eryph.ConfigModel.System.Json.csproj", "{36BEDF84-9E74-4A6A-A8B3-5D0FF7D2CCF1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Abstractions", "src\Eryph.ConfigModel.Abstractions\Eryph.ConfigModel.Abstractions.csproj", "{1A16AF8E-9F3F-4F11-89D4-22EDFF62FCC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Abstractions", "src\Eryph.ConfigModel.Abstractions\Eryph.ConfigModel.Abstractions.csproj", "{1A16AF8E-9F3F-4F11-89D4-22EDFF62FCC7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Core", "src\Eryph.ConfigModel.Core\Eryph.ConfigModel.Core.csproj", "{17C56C7B-6D72-4A97-9071-05914C2B8434}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Core", "src\Eryph.ConfigModel.Core\Eryph.ConfigModel.Core.csproj", "{17C56C7B-6D72-4A97-9071-05914C2B8434}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Networks", "src\Eryph.ConfigModel.Networks\Eryph.ConfigModel.Networks.csproj", "{A4C99176-29CE-4AE1-BE05-DA2337AC8EE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Networks", "src\Eryph.ConfigModel.Networks\Eryph.ConfigModel.Networks.csproj", "{A4C99176-29CE-4AE1-BE05-DA2337AC8EE2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Networks.Tests", "test\Eryph.ConfigModel.Networks.Tests\Eryph.ConfigModel.Networks.Tests.csproj", "{A84B3397-1572-4F17-AE73-ADE42AE61DA9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Networks.Tests", "test\Eryph.ConfigModel.Networks.Tests\Eryph.ConfigModel.Networks.Tests.csproj", "{A84B3397-1572-4F17-AE73-ADE42AE61DA9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Catlets.Yaml", "src\Eryph.ConfigModel.Catlets.Yaml\Eryph.ConfigModel.Catlets.Yaml.csproj", "{5B8E1D21-50D9-4EC7-9775-D831A4E65664}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Catlets.Yaml", "src\Eryph.ConfigModel.Catlets.Yaml\Eryph.ConfigModel.Catlets.Yaml.csproj", "{5B8E1D21-50D9-4EC7-9775-D831A4E65664}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Networks.Yaml", "src\Eryph.ConfigModel.Networks.Yaml\Eryph.ConfigModel.Networks.Yaml.csproj", "{B58D8917-6B08-4B4E-90FB-CD58DC0DFBEB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Networks.Yaml", "src\Eryph.ConfigModel.Networks.Yaml\Eryph.ConfigModel.Networks.Yaml.csproj", "{B58D8917-6B08-4B4E-90FB-CD58DC0DFBEB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.ConfigModel.Core.Tests", "test\Eryph.ConfigModel.Core.Tests\Eryph.ConfigModel.Core.Tests.csproj", "{D6E54F22-FAE7-48F0-89C1-92BE22C215CE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{B58D8917-6B08-4B4E-90FB-CD58DC0DFBEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B58D8917-6B08-4B4E-90FB-CD58DC0DFBEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B58D8917-6B08-4B4E-90FB-CD58DC0DFBEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6E54F22-FAE7-48F0-89C1-92BE22C215CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6E54F22-FAE7-48F0-89C1-92BE22C215CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6E54F22-FAE7-48F0-89C1-92BE22C215CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6E54F22-FAE7-48F0-89C1-92BE22C215CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,3 @@
-
 <Project>
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -12,16 +11,17 @@
     <RepositoryUrl>https://github.com/eryph-org/dotnet-configmodel</RepositoryUrl>
     <RootNamespace>Eryph.ConfigModel</RootNamespace>
     <!-- Declare that the Repository URL can be published to NuSpec -->
-  <PublishRepositoryUrl>true</PublishRepositoryUrl>
-  <!-- Embed source files that are not tracked by the source control manager to the PDB -->
-  <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  <!-- Include PDB in the built .nupkg -->
-  <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-
-  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Embed source files that are not tracked by the source control manager to the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Include PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
 
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">True</ContinuousIntegrationBuild>
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Eryph.ConfigModel.Abstractions/Converters/IConverterContext.cs
+++ b/src/Eryph.ConfigModel.Abstractions/Converters/IConverterContext.cs
@@ -5,7 +5,7 @@ namespace Eryph.ConfigModel.Converters
     public interface IConverterContext<T>
     {
         T? Target { get; set; }
-        IDictionary<object, object> Input { get; }
+        
         IDictionaryConverterProvider<T> ConverterProvider { get; }
         TRes? Convert<TRes>(IDictionary<object, object> dictionary, object? data = null) where TRes : class;
         TRes[]? ConvertList<TRes>(IDictionary<object, object> dictionary, object? data = null) where TRes : class;

--- a/src/Eryph.ConfigModel.Abstractions/Eryph.ConfigModel.Abstractions.csproj
+++ b/src/Eryph.ConfigModel.Abstractions/Eryph.ConfigModel.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Abstractions/Eryph.ConfigModel.Abstractions.csproj
+++ b/src/Eryph.ConfigModel.Abstractions/Eryph.ConfigModel.Abstractions.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Catlets.Yaml/Eryph.ConfigModel.Catlets.Yaml.csproj
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/Eryph.ConfigModel.Catlets.Yaml.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
+        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Catlets.Yaml/Eryph.ConfigModel.Catlets.Yaml.csproj
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/Eryph.ConfigModel.Catlets.Yaml.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletConfigDictionaryConverter.cs
@@ -36,7 +36,7 @@ namespace Eryph.ConfigModel.Catlets
                 new StrictCatletCapabilityConfigConverter.List()
             };
 
-            var context = new ConverterContext<CatletConfig>(dictionary,
+            var context = new ConverterContext<CatletConfig>(
                 new DictionaryConverterProvider<CatletConfig>(converters));
 
             return context.Convert<CatletConfig>(dictionary) ?? new CatletConfig();

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveConfig.cs
@@ -47,13 +47,14 @@ namespace Eryph.ConfigModel.Catlets
                 (drive, childDrive) =>
                 {
 
-                    if (childDrive.Type.HasValue && drive.Type != childDrive.Type)
+                    if (childDrive.Type.HasValue && (drive.Type ?? CatletDriveType.VHD) != childDrive.Type)
                         drive.Source = null;
                     
                     drive.Type = childDrive.Type ?? drive.Type;
                     drive.Source = childDrive.Source ?? drive.Source;
                     
-                    if (childDrive.Size != 0) drive.Size = childDrive.Size;
+                    if ((childDrive.Size ?? 0) != 0)
+                        drive.Size = childDrive.Size;
                     if (!string.IsNullOrWhiteSpace(childDrive.Location))
                         drive.Location = childDrive.Location;
                     if (!string.IsNullOrWhiteSpace(childDrive.Store))

--- a/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/Converters/FodderConfigConverter.cs
@@ -24,22 +24,12 @@ namespace Eryph.ConfigModel.Catlets.Converters
                 Source = GetStringProperty(dictionary, nameof(FodderConfig.Source)),
                 Type = GetStringProperty(dictionary, nameof(FodderConfig.Type)),
                 Content = GetStringProperty(dictionary, nameof(FodderConfig.Content)),
-                FileName = GetStringProperty(dictionary, nameof(FodderConfig.FileName))
+                FileName = GetStringProperty(dictionary, nameof(FodderConfig.FileName)),
+                Secret = GetBoolProperty(dictionary, nameof(FodderConfig.Secret)),
+                Remove = GetBoolProperty(dictionary, nameof(FodderConfig.Remove)),
             };
-
-            var secretString = GetStringProperty(dictionary, nameof(FodderConfig.Secret));
-            if(!string.IsNullOrEmpty(secretString))
-                res.Secret = bool.Parse(secretString);
-
-            var removeString = GetStringProperty(dictionary, nameof(FodderConfig.Remove));
-            if (!string.IsNullOrEmpty(removeString))
-                res.Remove = bool.Parse(removeString);
-
 
             return res;
         }
-
-
-
     }
 }

--- a/src/Eryph.ConfigModel.Catlets/Eryph.ConfigModel.Catlets.csproj
+++ b/src/Eryph.ConfigModel.Catlets/Eryph.ConfigModel.Catlets.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Catlets/Eryph.ConfigModel.Catlets.csproj
+++ b/src/Eryph.ConfigModel.Catlets/Eryph.ConfigModel.Catlets.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Catlets/FodderGenes/FodderConfigDictionaryConverter.cs
@@ -19,7 +19,7 @@ public static class FodderGeneConfigDictionaryConverter
             new FodderConfigConverter<FodderGeneConfig>.List(),
         };
 
-        var context = new ConverterContext<FodderGeneConfig>(dictionary,
+        var context = new ConverterContext<FodderGeneConfig>(
             new DictionaryConverterProvider<FodderGeneConfig>(converters));
 
         return context.Convert<FodderGeneConfig>(dictionary) ?? new FodderGeneConfig();

--- a/src/Eryph.ConfigModel.Core/Converters/ConverterContext.cs
+++ b/src/Eryph.ConfigModel.Core/Converters/ConverterContext.cs
@@ -6,15 +6,12 @@ namespace Eryph.ConfigModel.Converters
 {
     public class ConverterContext<T> : IConverterContext<T>
     {
-        public ConverterContext(IDictionary<object, object> input, IDictionaryConverterProvider<T> converterProvider)
+        public ConverterContext(IDictionaryConverterProvider<T> converterProvider)
         {
-            Input = input;
             ConverterProvider = converterProvider;
         }
 
         public T? Target { get; set; }
-
-        public IDictionary<object, object> Input { get; }
 
         public IDictionaryConverterProvider<T> ConverterProvider { get;  }
 

--- a/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
+++ b/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
@@ -76,7 +76,7 @@ namespace Eryph.ConfigModel.Converters
                 return null;
 
             if(!int.TryParse(value, out var result))
-                throw new InvalidConfigModelException($"The value for {propertyNames.FirstOrDefault()} is invalid");
+                throw new InvalidConfigModelException($"The value for {propertyNames[0]} is invalid");
 
             return result;
         }
@@ -88,7 +88,7 @@ namespace Eryph.ConfigModel.Converters
                 return null;
 
             if (!bool.TryParse(stringValue, out var value))
-                throw new InvalidConfigModelException($"The value for {propertyNames.FirstOrDefault()} is invalid");
+                throw new InvalidConfigModelException($"The value for {propertyNames[0]} is invalid");
 
             return value;
         }

--- a/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
+++ b/src/Eryph.ConfigModel.Core/Converters/DictionaryConverterBase.cs
@@ -71,7 +71,26 @@ namespace Eryph.ConfigModel.Converters
 
         protected static int? GetIntProperty(IDictionary<object, object> dictionary, params string[] propertyNames)
         {
-            return Convert.ToInt32(GetValueCaseInvariant(dictionary, propertyNames));
+            var value = GetStringProperty(dictionary, propertyNames);
+            if (value is null)
+                return null;
+
+            if(!int.TryParse(value, out var result))
+                throw new InvalidConfigModelException($"The value for {propertyNames.FirstOrDefault()} is invalid");
+
+            return result;
+        }
+
+        protected static bool? GetBoolProperty(IDictionary<object, object> dictionary, params string[] propertyNames)
+        {
+            var stringValue = GetStringProperty(dictionary, propertyNames);
+            if (stringValue is null)
+                return null;
+
+            if (!bool.TryParse(stringValue, out var value))
+                throw new InvalidConfigModelException($"The value for {propertyNames.FirstOrDefault()} is invalid");
+
+            return value;
         }
     }
 }

--- a/src/Eryph.ConfigModel.Core/Eryph.ConfigModel.Core.csproj
+++ b/src/Eryph.ConfigModel.Core/Eryph.ConfigModel.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Core/Eryph.ConfigModel.Core.csproj
+++ b/src/Eryph.ConfigModel.Core/Eryph.ConfigModel.Core.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.Networks.Yaml/Eryph.ConfigModel.Networks.Yaml.csproj
+++ b/src/Eryph.ConfigModel.Networks.Yaml/Eryph.ConfigModel.Networks.Yaml.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
+        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Networks.Yaml/Eryph.ConfigModel.Networks.Yaml.csproj
+++ b/src/Eryph.ConfigModel.Networks.Yaml/Eryph.ConfigModel.Networks.Yaml.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Networks/Eryph.ConfigModel.Networks.csproj
+++ b/src/Eryph.ConfigModel.Networks/Eryph.ConfigModel.Networks.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
+        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Networks/Eryph.ConfigModel.Networks.csproj
+++ b/src/Eryph.ConfigModel.Networks/Eryph.ConfigModel.Networks.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
         <NoWarn>1701;1702;1705;1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Eryph.ConfigModel.Networks/Networks/ProjectNetworksConfigDictionaryConverter.cs
+++ b/src/Eryph.ConfigModel.Networks/Networks/ProjectNetworksConfigDictionaryConverter.cs
@@ -24,7 +24,7 @@ namespace Eryph.ConfigModel.Networks
                 new IpPoolConfigConverter.List()
             };
 
-            var context = new ConverterContext<ProjectNetworksConfig>(dictionary,
+            var context = new ConverterContext<ProjectNetworksConfig>(
                 new DictionaryConverterProvider<ProjectNetworksConfig>(converters));
 
             return context.Convert<ProjectNetworksConfig>(dictionary);

--- a/src/Eryph.ConfigModel.System.Json/Eryph.ConfigModel.System.Json.csproj
+++ b/src/Eryph.ConfigModel.System.Json/Eryph.ConfigModel.System.Json.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eryph.ConfigModel.System.Json/Eryph.ConfigModel.System.Json.csproj
+++ b/src/Eryph.ConfigModel.System.Json/Eryph.ConfigModel.System.Json.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/BreedingTests.cs
@@ -199,6 +199,46 @@ public class BreedingTests
     }
 
     [Fact]
+    public void Drive_with_default_values_is_merged()
+    {
+        var parent = new CatletConfig
+        {
+            Name = "Parent",
+            Drives =
+            [
+                new CatletDriveConfig
+                {
+                    Name = "sda",
+                    Size = 100,
+                }
+            ]
+        };
+
+        var child = new CatletConfig
+        {
+            Name = "child", 
+            Drives =
+            [
+                new CatletDriveConfig
+                {
+                    Name = "sda",
+                    Type = CatletDriveType.VHD,
+                }
+            ]
+        };
+
+        var breedChild = parent.Breed(child, "reference");
+
+        breedChild.Drives.Should().SatisfyRespectively(
+            breedDrive =>
+            {
+                breedDrive.Name.Should().Be("sda");
+                breedDrive.Size.Should().Be(100);
+                breedDrive.Source.Should().Be("gene:reference:sda");
+            });
+    }
+    
+    [Fact]
     public void NetworkAdapters_are_merged()
     {
         var parent = new CatletConfig

--- a/test/Eryph.ConfigModel.Catlets.Tests/Eryph.ConfigModel.Catlets.Tests.csproj
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Eryph.ConfigModel.Catlets.Tests.csproj
@@ -13,13 +13,13 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Eryph.ConfigModel.Catlets.Tests/Eryph.ConfigModel.Catlets.Tests.csproj
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Eryph.ConfigModel.Catlets.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Eryph.ConfigModel.Catlet.Tests</RootNamespace>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Eryph.ConfigModel.Core.Tests/DictionaryConverterBaseTests.cs
+++ b/test/Eryph.ConfigModel.Core.Tests/DictionaryConverterBaseTests.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Converters;
+using YamlDotNet.Core.Tokens;
+using YamlDotNet.Serialization;
+
+namespace Eryph.ConfigModel.Core.Tests
+{
+    public class DictionaryConverterBaseTests
+    {
+        [Theory]
+        [InlineData("StringValue")]
+        [InlineData("stringvalue")]
+        [InlineData("STRINGVALUE")]
+        [InlineData("string_value")]
+        public void ConvertFromDictionary_CompatiblePropertyName_ReturnsValue(
+            string propertyName)
+        {
+            const string value = "lorem ipsum";
+            var dictionary = new Dictionary<object, object>
+            {
+                [propertyName] = value,
+            };
+
+            var result = ConvertFromDictionary(dictionary);
+
+            result.Should().NotBeNull();
+            result!.StringValue.Should().Be(value);
+
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(true, true)]
+        [InlineData("true", true)]
+        [InlineData("True", true)]
+        public void ConvertFromDictionary_ValidBooleanValue_ReturnsBoolean(
+            object? value,
+            bool? expected)
+        {
+            var dictionary = new Dictionary<object, object>
+            {
+                ["BooleanValue"] = value!,
+            };
+
+            var result = ConvertFromDictionary(dictionary);
+            result.Should().NotBeNull();
+            result!.BooleanValue.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("lorem")]
+        public void ConvertFromDictionary_InvalidBooleanValue_ThrowsException(
+            object? value)
+        {
+            var dictionary = new Dictionary<object, object>
+            {
+                ["BooleanValue"] = value!,
+            };
+
+            FluentActions.Invoking(() => ConvertFromDictionary(dictionary))
+                .Should().Throw<InvalidConfigModelException>()
+                .Which.Message.Should().Contain("BooleanValue");
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(1, 1)]
+        [InlineData("1", 1)]
+        public void ConvertFromDictionary_ValidIntegerValue_ReturnsInteger(
+            object? value,
+            int? expected)
+        {
+            var dictionary = new Dictionary<object, object>
+            {
+                ["IntegerValue"] = value!,
+            };
+
+            var result = ConvertFromDictionary(dictionary);
+            result.Should().NotBeNull();
+            result!.IntegerValue.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(1.5)]
+        [InlineData("1.5")]
+        public void ConvertFromDictionary_InvalidIntegerValue_ThrowsException(
+            object? value)
+        {
+            var dictionary = new Dictionary<object, object>
+            {
+                ["IntegerValue"] = value!,
+            };
+
+            FluentActions.Invoking(() => ConvertFromDictionary(dictionary))
+                .Should().Throw<InvalidConfigModelException>()
+                .Which.Message.Should().Contain("IntegerValue");
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("lorem ipsum", "lorem ipsum")]
+        public void ConvertFromDictionary_ValidStringValue_ReturnsString(
+            object? value,
+            string? expected)
+        {
+            var dictionary = new Dictionary<object, object>
+            {
+                ["StringValue"] = value!,
+            };
+
+            var result = ConvertFromDictionary(dictionary);
+            
+            result.Should().NotBeNull();
+            result!.StringValue.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ConvertFromDictionary_ValidYaml_ReturnsValidObject()
+        {
+            string yaml = """
+                          BooleanValue: true
+                          IntegerValue: 42
+                          StringValue: lorem ipsum
+                          """;
+
+            var deserializer = new DeserializerBuilder().Build();
+            var dictionary = deserializer.Deserialize<Dictionary<object, object>>(yaml);
+
+            var result = ConvertFromDictionary(dictionary.ToDictionary(kv => (object)kv.Key, kv => kv.Value));
+            
+            result.Should().NotBeNull();
+            result!.BooleanValue.Should().BeTrue();
+            result.IntegerValue.Should().Be(42);
+            result.StringValue.Should().Be("lorem ipsum");
+        }
+
+        [Fact]
+        public void ConvertFromDictionary_ValidJson_ReturnsValidObject()
+        {
+            string json = """
+                          {
+                            "BooleanValue": true,
+                            "IntegerValue": 42,
+                            "StringValue": "lorem ipsum"
+                          }
+                          """;
+
+            var dictionary = JsonSerializer.Deserialize<Dictionary<string, object?>>(json)
+                ?.ToDictionary(kv => (object)kv.Key, kv => kv.Value);
+
+            dictionary.Should().NotBeNull();
+
+            var result = ConvertFromDictionary(dictionary!);
+            
+            result.Should().NotBeNull();
+            result!.BooleanValue.Should().BeTrue();
+            result.IntegerValue.Should().Be(42);
+            result.StringValue.Should().Be("lorem ipsum");
+        }
+
+        private static TestModel? ConvertFromDictionary(IDictionary<object, object> dictionary)
+        {
+            var context = new ConverterContext<TestModel>(dictionary, new DictionaryConverterProvider<TestModel>(Array.Empty<IDictionaryConverter<TestModel>>()));
+            var converter = new TestModelDictionaryConverter();
+
+            return converter.ConvertFromDictionary(context, dictionary);
+        }
+
+        private class TestModelDictionaryConverter : DictionaryConverterBase<TestModel, TestModel>
+        {
+            public override TestModel? ConvertFromDictionary(
+                IConverterContext<TestModel> context,
+                IDictionary<object, object> dictionary,
+                object? data = default)
+            {
+                return new TestModel()
+                {
+                    BooleanValue = GetBoolProperty(dictionary, nameof(TestModel.BooleanValue)),
+                    IntegerValue = GetIntProperty(dictionary, nameof(TestModel.IntegerValue)),
+                    StringValue = GetStringProperty(dictionary, nameof(TestModel.StringValue)),
+                };
+            }
+        }
+
+        private class TestModel
+        {
+            public bool? BooleanValue { get; init; }
+
+            public int? IntegerValue { get; init; }
+
+            public string? StringValue { get; init; }
+        }
+    }
+}

--- a/test/Eryph.ConfigModel.Core.Tests/DictionaryConverterBaseTests.cs
+++ b/test/Eryph.ConfigModel.Core.Tests/DictionaryConverterBaseTests.cs
@@ -170,7 +170,7 @@ namespace Eryph.ConfigModel.Core.Tests
 
         private static TestModel? ConvertFromDictionary(IDictionary<object, object> dictionary)
         {
-            var context = new ConverterContext<TestModel>(dictionary, new DictionaryConverterProvider<TestModel>(Array.Empty<IDictionaryConverter<TestModel>>()));
+            var context = new ConverterContext<TestModel>(new DictionaryConverterProvider<TestModel>(Array.Empty<IDictionaryConverter<TestModel>>()));
             var converter = new TestModelDictionaryConverter();
 
             return converter.ConvertFromDictionary(context, dictionary);

--- a/test/Eryph.ConfigModel.Core.Tests/Eryph.ConfigModel.Core.Tests.csproj
+++ b/test/Eryph.ConfigModel.Core.Tests/Eryph.ConfigModel.Core.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Eryph.ConfigModel.Core.Tests/Eryph.ConfigModel.Core.Tests.csproj
+++ b/test/Eryph.ConfigModel.Core.Tests/Eryph.ConfigModel.Core.Tests.csproj
@@ -1,33 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <RootNamespace>Eryph.ConfigModel.Catlet.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-    <LangVersion>default</LangVersion>
+    <IsPackable>false</IsPackable>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
-      <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Eryph.ConfigModel.Networks.Yaml\Eryph.ConfigModel.Networks.Yaml.csproj" />
-    <ProjectReference Include="..\..\src\Eryph.ConfigModel.System.Json\Eryph.ConfigModel.System.Json.csproj" />
+    <ProjectReference Include="..\..\src\Eryph.ConfigModel.Core\Eryph.ConfigModel.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Eryph.ConfigModel.Core.Tests/Usings.cs
+++ b/test/Eryph.ConfigModel.Core.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using FluentAssertions;
+global using Xunit;

--- a/test/Eryph.ConfigModel.Networks.Tests/Eryph.ConfigModel.Networks.Tests.csproj
+++ b/test/Eryph.ConfigModel.Networks.Tests/Eryph.ConfigModel.Networks.Tests.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Eryph.ConfigModel.Catlet.Tests</RootNamespace>
     <Nullable>enable</Nullable>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <LangVersion>default</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Eryph.ConfigModel.Networks.Tests/Eryph.ConfigModel.Networks.Tests.csproj
+++ b/test/Eryph.ConfigModel.Networks.Tests/Eryph.ConfigModel.Networks.Tests.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Eryph.ConfigModel.Catlet.Tests</RootNamespace>
     <Nullable>enable</Nullable>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix null value handling during breeding and deserialization.

The old code in `DictionaryConverterBase` always converted `null` to `0` for integer properties.