### PR TITLE
keep order of fodder in breeding

### DIFF
--- a/ConfigModel.sln
+++ b/ConfigModel.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.8.34525.116
+VisualStudioVersion = 17.8.34309.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ConfigModel.Catlets", "src\Eryph.ConfigModel.Catlets\Eryph.ConfigModel.Catlets.csproj", "{C71E688F-5BB5-4350-BD76-0CF0E2EC9473}"
 EndProject

--- a/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/FodderConfig.cs
@@ -96,7 +96,7 @@ namespace Eryph.ConfigModel.Catlets
                                           string.Equals(x, cfg.Name, StringComparison.InvariantCultureIgnoreCase))) 
                                   ?? Array.Empty<FodderConfig>());
 
-            return mergedConfig.OrderBy(x => x.Name).ToArray();
+            return mergedConfig.ToArray();
 
         }
     }

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/ConverterTestBase.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/ConverterTestBase.cs
@@ -63,12 +63,13 @@ public class ConverterTestBase
 
         config.Hostname.Should().Be("cinc-host");
         config.Fodder.Should().NotBeNull();
-        config.Fodder.Should().HaveCount(1);
-        config.Fodder?[0].Name.Should().Be("admin-windows");
-        config.Fodder?[0].Type.Should().Be("cloud-config");
-        config.Fodder?[0].FileName.Should().Be("filename");
-        config.Fodder?[0].Secret.Should().Be(true);
-        config.Fodder?[0].Content.Should().Contain("- name: Admin");
-        config.Fodder?[0].Content.Should().NotEndWith("\0");
+        config.Fodder.Should().HaveCount(2);
+        config.Fodder?[0].Name.Should().Be("first");
+        config.Fodder?[1].Name.Should().Be("admin-windows");
+        config.Fodder?[1].Type.Should().Be("cloud-config");
+        config.Fodder?[1].FileName.Should().Be("filename");
+        config.Fodder?[1].Secret.Should().Be(true);
+        config.Fodder?[1].Content.Should().Contain("- name: Admin");
+        config.Fodder?[1].Content.Should().NotEndWith("\0");
     }
 }

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/JsonConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/JsonConverterTests.cs
@@ -79,6 +79,9 @@ public class JsonConverterTests : ConverterTestBase
   ],
   ""fodder"": [
     {{
+      ""name"": ""first""
+    }},
+    {{
       ""name"": ""admin-windows"",
       ""type"": ""cloud-config"",
       ""content"": ""users:\n  - name: Admin\ngroups: [ \u0022Administrators\u0022 ]\n  passwd: InitialPassw0rd"",

--- a/test/Eryph.ConfigModel.Catlets.Tests/Catlets/YamlConverterTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/Catlets/YamlConverterTests.cs
@@ -55,6 +55,7 @@ networks:
 - name: backup
   adapter_name: eth1
 fodder:
+- name: first
 - name: admin-windows
   type: cloud-config
   content: >-


### PR DESCRIPTION
This PR adds test that show that the assumption from issue #53 is wrong at least for parsing the config entries from yaml to dictionary.
The actual case of this issue is that fodder is sorted by name in breeding - this was removed. 

solves #53 