### PR TITLE
add vhdset as drive type

### DIFF
--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveType.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletDriveType.cs
@@ -9,7 +9,8 @@ namespace Eryph.ConfigModel.Catlets
         VHD = 0,
         SharedVHD = 1,
         PHD = 2,
-        DVD = 3
+        DVD = 3,
+        VHDSet = 4,
         // ReSharper restore InconsistentNaming
     }
 }


### PR DESCRIPTION
Adds support for VHD Sets in drive type. Allows to configure both shared disks and VHD Sets.