### PR TITLE
Disable anchor support for YAML serialization

### DIFF
--- a/src/Eryph.ConfigModel.Catlets.Yaml/CatletConfigYamlSerializer.cs
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/CatletConfigYamlSerializer.cs
@@ -39,6 +39,7 @@ public static class CatletConfigYamlSerializer
                 c => c.Content!,
                 new YamlMemberAttribute { ScalarStyle = ScalarStyle.Literal })
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+            .DisableAliases()
             .Build());
 
     public static CatletConfig Deserialize(string yaml)

--- a/src/Eryph.ConfigModel.Catlets.Yaml/FodderGeneConfigYamlSerializer.cs
+++ b/src/Eryph.ConfigModel.Catlets.Yaml/FodderGeneConfigYamlSerializer.cs
@@ -28,6 +28,7 @@ public static class FodderGeneConfigYamlSerializer
                 c => c.Content!,
                 new YamlMemberAttribute { ScalarStyle = ScalarStyle.Literal })
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+            .DisableAliases()
             .Build());
 
     public static FodderGeneConfig Deserialize(string yaml)

--- a/src/Eryph.ConfigModel.Networks.Yaml/ProjectNetworksConfigYamlSerializer.cs
+++ b/src/Eryph.ConfigModel.Networks.Yaml/ProjectNetworksConfigYamlSerializer.cs
@@ -28,6 +28,7 @@ public static class ProjectNetworksConfigYamlSerializer
         new SerializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+            .DisableAliases()
             .Build());
 
     public static ProjectNetworksConfig Deserialize(string yaml)

--- a/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigYamlSerializerTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigYamlSerializerTests.cs
@@ -1,7 +1,10 @@
 using System;
 using CultureAwareTesting.xUnit;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Variables;
 using Eryph.ConfigModel.Yaml;
 using FluentAssertions;
+using Xunit;
 using YamlDotNet.Core;
 
 namespace Eryph.ConfigModel.Catlet.Tests;
@@ -366,5 +369,35 @@ public class CatletConfigYamlSerializerTests : CatletConfigSerializerTestBase
         var result = CatletConfigYamlSerializer.Serialize(config);
 
         result.Should().Be(ComplexConfigYaml);
+    }
+
+    [Fact]
+    public void Serialize_SameDataOccursMultipleTimes_ReturnsYamlWithoutAnchors()
+    {
+        var variableConfig = new VariableConfig
+        {
+            Name = "username",
+            Value = "jane",
+        };
+
+        var config = new CatletConfig
+        {
+            Fodder =
+            [
+                new FodderConfig
+                {
+                    Name = "first",
+                    Variables = [variableConfig],
+                },
+                new FodderConfig
+                {
+                    Name = "second",
+                    Variables = [variableConfig],
+                },
+            ],
+        };
+
+        var result = CatletConfigYamlSerializer.Serialize(config);
+        result.Should().NotContain("&").And.NotContain("*");
     }
 }

--- a/test/Eryph.ConfigModel.Catlets.Tests/FodderGeneConfigYamlSerializerTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/FodderGeneConfigYamlSerializerTests.cs
@@ -1,7 +1,11 @@
 using System;
 using CultureAwareTesting.xUnit;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.FodderGenes;
+using Eryph.ConfigModel.Variables;
 using Eryph.ConfigModel.Yaml;
 using FluentAssertions;
+using Xunit;
 using YamlDotNet.Core;
 
 namespace Eryph.ConfigModel.Catlet.Tests;
@@ -255,5 +259,35 @@ public class FodderGeneConfigYamlSerializerTests : FodderGeneConfigSerializerTes
         var result = FodderGeneConfigYamlSerializer.Serialize(config);
 
         result.Should().BeEquivalentTo(ComplexConfigYaml);
+    }
+
+    [Fact]
+    public void Serialize_SameDataOccursMultipleTimes_ReturnsYamlWithoutAnchors()
+    {
+        var variableConfig = new VariableConfig
+        {
+            Name = "username",
+            Value = "jane",
+        };
+
+        var config = new FodderGeneConfig()
+        {
+            Fodder =
+            [
+                new FodderConfig
+                {
+                    Name = "first",
+                    Variables = [variableConfig],
+                },
+                new FodderConfig
+                {
+                    Name = "second",
+                    Variables = [variableConfig],
+                },
+            ],
+        };
+
+        var result = FodderGeneConfigYamlSerializer.Serialize(config);
+        result.Should().NotContain("&").And.NotContain("*");
     }
 }

--- a/test/Eryph.ConfigModel.Networks.Tests/ProjectNetworksConfigYamlSerializerTests.cs
+++ b/test/Eryph.ConfigModel.Networks.Tests/ProjectNetworksConfigYamlSerializerTests.cs
@@ -2,6 +2,7 @@ using System;
 using CultureAwareTesting.xUnit;
 using Eryph.ConfigModel.Yaml;
 using FluentAssertions;
+using Xunit;
 using YamlDotNet.Core;
 
 namespace Eryph.ConfigModel.Networks.Tests;
@@ -115,5 +116,35 @@ public class ProjectNetworksConfigYamlSerializerTests : ProjectNetworksConfigSer
         var result = ProjectNetworksConfigYamlSerializer.Serialize(config);
 
         result.Should().Be(ComplexConfigYaml);
+    }
+
+    [Fact]
+    public void Serialize_SameDataOccursMultipleTimes_ReturnsYamlWithoutAnchors()
+    {
+        var subnetConfig = new NetworkSubnetConfig
+        {
+            Name = "subnet",
+            Address = "10.0.0.0/24",
+        };
+
+        var config = new ProjectNetworksConfig()
+        {
+            Networks =
+            [
+                new NetworkConfig
+                {
+                    Name = "first",
+                    Subnets = [subnetConfig],
+                },
+                new NetworkConfig
+                {
+                    Name = "second",
+                    Subnets = [subnetConfig],
+                },
+            ],
+        };
+
+        var result = ProjectNetworksConfigYamlSerializer.Serialize(config);
+        result.Should().NotContain("&").And.NotContain("*");
     }
 }


### PR DESCRIPTION
This PR disables the support for anchors (references) in the YAML serialization.