### PR TITLE
Add support for MAC address spoofing

### DIFF
--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
@@ -12,6 +12,8 @@ public class CatletNetworkAdapterConfig : IMutateableConfig<CatletNetworkAdapter
         
     public string? MacAddress { get; set; }
 
+    public bool? EnableMacAddressSpoofing { get; set; }
+
     public CatletNetworkAdapterConfig Clone() => new()
     {
         Name = Name,

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
@@ -14,11 +14,17 @@ public class CatletNetworkAdapterConfig : IMutateableConfig<CatletNetworkAdapter
 
     public bool? MacAddressSpoofing { get; set; }
 
+    public bool? DhcpGuard { get; set; }
+
+    public bool? RouterGuard { get; set; }
+
     public CatletNetworkAdapterConfig Clone() => new()
     {
         Name = Name,
         Mutation = Mutation,
         MacAddress = MacAddress,
         MacAddressSpoofing = MacAddressSpoofing,
+        DhcpGuard = DhcpGuard,
+        RouterGuard = RouterGuard,
     };
 }

--- a/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
+++ b/src/Eryph.ConfigModel.Catlets/Catlets/CatletNetworkAdapterConfig.cs
@@ -12,12 +12,13 @@ public class CatletNetworkAdapterConfig : IMutateableConfig<CatletNetworkAdapter
         
     public string? MacAddress { get; set; }
 
-    public bool? EnableMacAddressSpoofing { get; set; }
+    public bool? MacAddressSpoofing { get; set; }
 
     public CatletNetworkAdapterConfig Clone() => new()
     {
         Name = Name,
         Mutation = Mutation,
-        MacAddress = MacAddress
+        MacAddress = MacAddress,
+        MacAddressSpoofing = MacAddressSpoofing,
     };
 }

--- a/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigCloneableTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigCloneableTests.cs
@@ -42,7 +42,12 @@ public class CatletConfigCloneableTests
         ],
         NetworkAdapters =
         [
-            new CatletNetworkAdapterConfig { Name = "eth0" }
+            new CatletNetworkAdapterConfig
+            {
+                Name = "eth0",
+                MacAddress = "02:04:06:08:10:12",
+                MacAddressSpoofing = true,
+            }
         ],
         Variables =
         [
@@ -117,8 +122,12 @@ public class CatletConfigCloneableTests
             .Select(a => a.Clone())
             .ToArray();
 
-        cloned.Should().NotBeNull();
-        cloned.Should().HaveCount(1);
+        cloned.Should().SatisfyRespectively(
+            c =>
+            {
+                c.Should().NotBeSameAs(TestData.Capabilities![0]);
+                c.Should().BeEquivalentTo(TestData.Capabilities![0]);
+            });
     }
 
     [Fact]
@@ -128,8 +137,12 @@ public class CatletConfigCloneableTests
             .Select(a => a.Clone())
             .ToArray();
 
-        cloned.Should().NotBeNull();
-        cloned.Should().HaveCount(1);
+        cloned.Should().SatisfyRespectively(
+            c =>
+            {
+                c.Should().NotBeSameAs(TestData.NetworkAdapters![0]);
+                c.Should().BeEquivalentTo(TestData.NetworkAdapters![0]);
+            });
     }
 
     [Fact]
@@ -139,8 +152,12 @@ public class CatletConfigCloneableTests
             .Select(a => a.Clone())
             .ToArray();
 
-        cloned.Should().NotBeNull();
-        cloned.Should().HaveCount(1);
+        cloned.Should().SatisfyRespectively(
+            c =>
+            {
+                c.Should().NotBeSameAs(TestData.Drives![0]);
+                c.Should().BeEquivalentTo(TestData.Drives![0]);
+            });
     }
 
     [Fact]
@@ -150,8 +167,12 @@ public class CatletConfigCloneableTests
             .Select(a => a.Clone())
             .ToArray();
 
-        cloned.Should().NotBeNull();
-        cloned.Should().HaveCount(1);
+        cloned.Should().SatisfyRespectively(
+            c =>
+            {
+                c.Should().NotBeSameAs(TestData.Networks![0]);
+                c.Should().BeEquivalentTo(TestData.Networks![0]);
+            });
     }
 
     [Fact]
@@ -161,8 +182,12 @@ public class CatletConfigCloneableTests
             .Select(a => a.Clone())
             .ToArray();
 
-        cloned.Should().NotBeNull();
-        cloned.Should().HaveCount(1);
+        cloned.Should().SatisfyRespectively(
+            c =>
+            {
+                c.Should().NotBeSameAs(TestData.Fodder![0]);
+                c.Should().BeEquivalentTo(TestData.Fodder![0]);
+            });
     }
 
     [Fact]

--- a/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigCloneableTests.cs
+++ b/test/Eryph.ConfigModel.Catlets.Tests/CatletConfigCloneableTests.cs
@@ -47,6 +47,8 @@ public class CatletConfigCloneableTests
                 Name = "eth0",
                 MacAddress = "02:04:06:08:10:12",
                 MacAddressSpoofing = true,
+                DhcpGuard = false,
+                RouterGuard = false,
             }
         ],
         Variables =


### PR DESCRIPTION
This PR adds the necessary configuration options for enabling MAC address spoofing and configuring the DHCP guard and router guard.